### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/animation.go
+++ b/animation.go
@@ -32,7 +32,7 @@ func Gif(g *gif.GIF, conv Converter, trans Transformer) Animation {
 
 type KeepLooping func() bool
 
-// Returns true until n calls have been made
+// LoopTimes returns true until n calls have been made
 func LoopTimes(n uint) KeepLooping {
 	loopCount := uint(0)
 	return func() bool {
@@ -48,7 +48,7 @@ func LoopTimes(n uint) KeepLooping {
 	}
 }
 
-// Returns true until s seconds have elapsed
+// LoopSeconds returns true until s seconds have elapsed
 func LoopSeconds(s uint) KeepLooping {
 	var c <-chan time.Time
 	return func() bool {

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -29,12 +29,12 @@ func colorize(fb uint8, i ColorCode, s string) string {
 	return fmt.Sprintf("\033[%d;5;%dm%s", fb, i, s)
 }
 
-// Returns string s with ColorCode i applied to the foreground
+// Fg returns string s with ColorCode i applied to the foreground
 func Fg(i ColorCode, s string) string {
 	return colorize(fgCode, i, s)
 }
 
-// Returns string s with ColorCode i applied to the background
+// Bg returns string s with ColorCode i applied to the background
 func Bg(i ColorCode, s string) string {
 	return colorize(bgCode, i, s)
 }
@@ -57,7 +57,7 @@ type winsize struct {
 	ypixels uint16
 }
 
-// Returns the size of the tty referenced by the provided file descriptor
+// Size returns the size of the tty referenced by the provided file descriptor
 func Size(fd uintptr) (uint, uint, error) {
 	var sz winsize
 	_, _, err := syscall.Syscall(syscall.SYS_IOCTL,


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?